### PR TITLE
Delete description section of the projects in projects pages

### DIFF
--- a/projects/templates/projects/list.html
+++ b/projects/templates/projects/list.html
@@ -52,13 +52,7 @@
                                                 {{project.organization.name|truncatechars:17}}
                                             </a>
                                         </h4>
-                                        <h5>Contributions: <code>{{ project.nb_contrib }}</code></h5>
-                                        <hr>
-                                        <p>
-                                            {% autoescape off %}
-                                                {{ project.description|truncatechars:200 }}
-                                            {% endautoescape %}
-                                        </p>
+                                        <h5>Contributions: <code>{{ project.nb_contrib }}</code></h5> 
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
The text of the description of the projects display the markdown of the original text. We don't have the time to code a function to correct that error so we decide to delete it.
