### PR TITLE
Correction of the link for share with social network

### DIFF
--- a/codetributhon/static/js/events.js
+++ b/codetributhon/static/js/events.js
@@ -5,12 +5,14 @@
 $(function(){
 
    var url = "";
+   var codetriUrl = "http://codetributhon.com";
 
    //partager sur facebook
     $('.share_fb').on('click', function (e){
         e.preventDefault();
 
-        url=$(this).data('url');
+//        url=$(this).data('url');
+        url=codetriUrl + $(this).data('url')
         var share_url = "https://www.facebook.com/sharer/sharer.php?u="+ encodeURIComponent(url) +"&amp;src=sdkprepars";
 
         sharePopupCenter(share_url, "Partagez sur Facebook1");
@@ -20,7 +22,7 @@ $(function(){
     $('.share_tw').on('click', function (e) {
         e.preventDefault();
 
-        url=$(this).data('url')
+        url=codetriUrl + $(this).data('url')
         var share_url = "https://twitter.com/intent/tweet?&url="+ encodeURIComponent(url) +"&via=codetributhon2016"
 
         sharePopupCenter(share_url, "Partagez sur twitter");
@@ -30,7 +32,8 @@ $(function(){
     $('.share_lkdin').on('click', function (e) {
         e.preventDefault();
 
-        url=$(this).data('url')
+//        url=$(this).data('url')
+        url=codetriUrl + $(this).data('url')
         var share_url = "https://www.linkedin.com/shareArticle?url="+ encodeURIComponent(url)
 
         sharePopupCenter(share_url, "Partagez sur linkedin");

--- a/events/templates/events/detail.html
+++ b/events/templates/events/detail.html
@@ -73,19 +73,19 @@
                             </a>
 		      </li>
 		      <li>
-			<button class="btn btn-md share_fb" data-url="{{events.url}}{% url 'events:event_detail' events.id %}" style="background-color:#4C67A1">
+			<button class="btn btn-md share_fb" data-url="{% url 'events:event_detail' events.id %}" style="background-color:#4C67A1">
 			  <i class="fa fa-facebook" aria-hideen="true"></i>
 			  Partager
 			</button>
 		      </li>
 		      <li>
-			<button class="btn btn-md share_tw" data-url="{{events.url}}{% url 'events:event_detail' events.id %}"  style="background-color:#55ACEE">
+			<button class="btn btn-md share_tw" data-url="{% url 'events:event_detail' events.id %}"  style="background-color:#55ACEE">
 			  <i class="fa fa-twitter" aria-hideen="true"></i>
 			  Partager
 			</button>
 		      </li>
 		      <li>
-			<button class="btn btn-md share_lkdin" data-url="{{events.url}}{% url 'events:event_detail' events.id %}" style="background-color:#0177B5">
+			<button class="btn btn-md share_lkdin" data-url="{% url 'events:event_detail' events.id %}" style="background-color:#0177B5">
 			  <i class="fa fa-linkedin" aria-hideen="true"></i>
 			  Partager
 			</button>

--- a/events/templates/events/list.html
+++ b/events/templates/events/list.html
@@ -73,17 +73,17 @@
                                     <div class="social">
                                         <ul>
                                             <li class="facebook" style="width:0;">
-                                                <a href="#" data-url="{{event.url}}{% url 'events:event_detail' event.id %}" class="share_fb">
+                                                <a href="#" data-url="{% url 'events:event_detail' event.id %}" class="share_fb">
                                                     <span class="fa fa-facebook"></span>
                                                 </a>
                                             </li>
                                             <li class="twitter" style="width:0;">
-                                                <a href="#" data-url="{{event.url}}{% url 'events:event_detail' event.id %}" class="share_tw">
+                                                <a href="#" data-url="{% url 'events:event_detail' event.id %}" class="share_tw">
                                                     <span class="fa fa-twitter"></span>
                                                 </a>
                                             </li>
                                             <li class="linkedin" style="width:0;">
-                                                <a href="#" data-url="{{event.url}}{% url 'events:event_detail' event.id %}" class="share_lkdin">
+                                                <a href="#" data-url="{% url 'events:event_detail' event.id %}" class="share_lkdin">
                                                     <span class="fa fa-linkedin"></span>
                                                 </a>
                                             </li>


### PR DESCRIPTION
We were using the register link and when it's a eventbrite link, the
share link don't work anymore. We had to correct in events list and
in  event description. Some adjustement in the javascript.
