### PR TITLE
Add translations to the FAQ page

### DIFF
--- a/faq/locale/en/LC_MESSAGES/django.po
+++ b/faq/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-10-31 14:19-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: .\faq\templates\faq\list.html:63
+msgid "Aucunes questions"
+msgstr "No Questions"

--- a/faq/locale/fr/LC_MESSAGES/django.po
+++ b/faq/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,23 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-10-31 14:19-0400\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: .\faq\templates\faq\list.html:63
+msgid "Aucunes questions"
+msgstr "Aucunes Questions"

--- a/faq/templates/faq/list.html
+++ b/faq/templates/faq/list.html
@@ -60,7 +60,7 @@
                         {% endfor %}
                     {% else %}
                         <div class="alert alert-warning">
-                            Aucunes questions
+                            {% trans "Aucunes questions" %}
                         </div>
                     {% endif %}
                 </div>


### PR DESCRIPTION
The FAQ page was missing translation.

Resolves: #104