### PR TITLE
Change the allow host in the settings

### DIFF
--- a/codetributhon/settings.py
+++ b/codetributhon/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'ml2k-pm-mmz%i+^__ax6&-vn_eex+(j5q@pjy!ij*i8f&xb)7@khm'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['http://104.196.16.145/']
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition


### PR DESCRIPTION
With this change, we can put the website in none debug mode.
The * in the "Allow Host" allow any host to be use.

Resolve: #98